### PR TITLE
feat: add support for toggling zone manager logic

### DIFF
--- a/examples/full-lipgloss/main.go
+++ b/examples/full-lipgloss/main.go
@@ -57,6 +57,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		// Example of toggling mouse event tracking on/off.
+		if msg.String() == "ctrl+e" {
+			zone.SetEnabled(!zone.Enabled())
+			return m, nil
+		}
+
 		if msg.String() == "ctrl+c" {
 			return m, tea.Quit
 		}

--- a/manager_global.go
+++ b/manager_global.go
@@ -6,13 +6,16 @@ package zone
 
 import tea "github.com/charmbracelet/bubbletea"
 
-// DefaultManager is a app-wide manager. To initialize it, call NewGlobal().
+// DefaultManager is an app-wide manager. To initialize it, call NewGlobal().
 var DefaultManager *Manager
 
 // NewGlobal initializes a global manager, so you don't have to pass the manager
 // between all components. This is primarily only useful if you have full control
 // of the zones you want to monitor, however if developing a library using this,
 // make sure you allow users to pass in their own manager.
+//
+// The zone manager is enabled by default, and can be toggled by calling
+// SetEnabled().
 func NewGlobal() {
 	if DefaultManager != nil {
 		return
@@ -27,51 +30,24 @@ func Close() {
 	DefaultManager.Close()
 }
 
-// Mark returns v wrapped with a start and end ANSI sequence to allow the zone
-// manager to determine where the zone is, including its window offsets. The ANSI
-// sequences used should be ignored by lipgloss width methods, to prevent incorrect
-// width calculations.
-func Mark(id, v string) string {
-	DefaultManager.checkInitialized()
-	return DefaultManager.Mark(id, v)
-}
-
-// Clear removes any stored zones for the given ID.
-func Clear(id string) {
-	DefaultManager.checkInitialized()
-	DefaultManager.Clear(id)
-}
-
-// Get returns the zone info of the given ID. If the ID is not known (yet),
-// Get() returns nil.
-func Get(id string) (a *ZoneInfo) {
-	DefaultManager.checkInitialized()
-	return DefaultManager.Get(id)
-}
-
-// Scan will scan the view output, searching for zone markers, returning the
-// original view output with the zone markers stripped. Scan() should be used
-// by the outer most model/component of your application, and not inside of a
-// model/component child.
+// SetEnabled enables or disables the zone manager. When disabled, the zone manager
+// will still parse zone information, however it will immediately drop it and remove
+// zone markers from the resulting output.
 //
-// Scan buffers the zone info to be stored, so an immediate call to Get(id) may
-// not return the correct information. Thus it's recommended to primarily use
-// Get(id) for actions like mouse events, which don't occur immediately after a
-// view shift (where the previously stored zone info might be different).
-func Scan(v string) string {
+// The zone manager is enabled by default.
+func SetEnabled(v bool) {
 	DefaultManager.checkInitialized()
-	return DefaultManager.Scan(v)
+	DefaultManager.enabled.Store(v)
 }
 
-// AnyInBounds sends a MsgZoneInBounds message to the provided model for each zone
-// that is in the bounds of the provided mouse event. The results of the call to
-// Update() are discarded.
+// Enabled returns whether the zone manager is enabled or not. When disabled,
+// the zone manager will still parse zone information, however it will immediately
+// drop it and remove zone markers from the resulting output.
 //
-// Note that if multiple zones are within bounds, each one will be sent as an event
-// in alphabetical sorted order of the ID.
-func AnyInBounds(model tea.Model, mouse tea.MouseMsg) {
+// The zone manager is enabled by default.
+func Enabled() bool {
 	DefaultManager.checkInitialized()
-	DefaultManager.AnyInBounds(model, mouse)
+	return DefaultManager.enabled.Load()
 }
 
 // NewPrefix generates a zone marker ID prefix, which can help prevent overlapping
@@ -79,6 +55,7 @@ func AnyInBounds(model tea.Model, mouse tea.MouseMsg) {
 // new unique prefix.
 //
 // Usage example:
+//
 //	func NewModel() tea.Model {
 //		return &model{
 //			id: zone.NewPrefix(),
@@ -112,4 +89,59 @@ func AnyInBounds(model tea.Model, mouse tea.MouseMsg) {
 func NewPrefix() string {
 	DefaultManager.checkInitialized()
 	return DefaultManager.NewPrefix()
+}
+
+// Mark returns v wrapped with a start and end ANSI sequence to allow the zone
+// manager to determine where the zone is, including its window offsets. The ANSI
+// sequences used should be ignored by lipgloss width methods, to prevent incorrect
+// width calculations.
+//
+// When the zone manager is disabled, Mark() will return v without any changes.
+func Mark(id, v string) string {
+	DefaultManager.checkInitialized()
+	return DefaultManager.Mark(id, v)
+}
+
+// Clear removes any stored zones for the given ID.
+func Clear(id string) {
+	DefaultManager.checkInitialized()
+	DefaultManager.Clear(id)
+}
+
+// Get returns the zone info of the given ID. If the ID is not known (yet),
+// Get() returns nil.
+func Get(id string) (a *ZoneInfo) {
+	DefaultManager.checkInitialized()
+	return DefaultManager.Get(id)
+}
+
+// Scan will scan the view output, searching for zone markers, returning the
+// original view output with the zone markers stripped. Scan() should be used
+// by the outer most model/component of your application, and not inside of a
+// model/component child.
+//
+// Scan buffers the zone info to be stored, so an immediate call to Get(id) may
+// not return the correct information. Thus it's recommended to primarily use
+// Get(id) for actions like mouse events, which don't occur immediately after a
+// view shift (where the previously stored zone info might be different).
+//
+// When the zone manager is disabled (via SetEnabled(false)), Scan() will return
+// the original view output with all zone markers stripped. It will still parse
+// the input for zone markers, as some users may cache generated views. In most
+// situations when the zone manager is disabled (and thus Mark() returns input
+// unchanged), Scan() will not need to do any work.
+func Scan(v string) string {
+	DefaultManager.checkInitialized()
+	return DefaultManager.Scan(v)
+}
+
+// AnyInBounds sends a MsgZoneInBounds message to the provided model for each zone
+// that is in the bounds of the provided mouse event. The results of the call to
+// Update() are discarded.
+//
+// Note that if multiple zones are within bounds, each one will be sent as an event
+// in alphabetical sorted order of the ID.
+func AnyInBounds(model tea.Model, mouse tea.MouseMsg) {
+	DefaultManager.checkInitialized()
+	DefaultManager.AnyInBounds(model, mouse)
 }

--- a/manager_test.go
+++ b/manager_test.go
@@ -128,6 +128,22 @@ func FuzzScan(f *testing.F) {
 	})
 }
 
+func TestScanDisabled(t *testing.T) {
+	zm := New()
+	defer zm.Close()
+
+	zm.SetEnabled(false)
+
+	for _, test := range testsScan {
+		t.Run(test.name, func(t *testing.T) {
+			got := zm.Scan(test.in)
+			if got != test.want {
+				t.Errorf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestMark(t *testing.T) {
 	var out string
 	for _, test := range testsScan[0:10] {
@@ -150,6 +166,19 @@ func BenchmarkMark(b *testing.B) {
 				_ = Mark(test.name, test.in)
 			}
 		})
+	}
+}
+
+func TestMarkDisabled(t *testing.T) {
+	zm := New()
+	defer zm.Close()
+
+	zm.SetEnabled(false)
+
+	for _, test := range testsScan[0:10] {
+		if got := zm.Mark(test.name, test.in); got != test.in {
+			t.Errorf("got %q, want %q", got, test.in)
+		}
 	}
 }
 


### PR DESCRIPTION
## 🚀 Changes proposed by this PR

Adds support for globally toggling zone management tracking (making `Mark()` and similar no-ops). This is primarily useful to allow users to toggle mouse support on and off without having to do most of that logic in the end-user application.


### 🔗 Related bug reports/feature requests

- implements #2

### 🧰 Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that causes existing functionality to not work as expected).
- [ ] This change requires (or is) a documentation update.

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
<!-- Include the below if this is a code change, if just documentation, ❌ remove this section. -->
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [x] 📝 I have made corresponding changes to the documentation.
- [x] 🧪 I have included tests (if necessary) for this change.
