### PR TITLE
Add AnyInBoundsAndUpdate

### DIFF
--- a/manager_global.go
+++ b/manager_global.go
@@ -145,3 +145,12 @@ func AnyInBounds(model tea.Model, mouse tea.MouseMsg) {
 	DefaultManager.checkInitialized()
 	DefaultManager.AnyInBounds(model, mouse)
 }
+
+// AnyInBoundsAndUpdate is the same as AnyInBounds; except the results of the calls
+// to Update() are carried through and returned.
+//
+// The tea.Cmd's that comd off the calls to Update() are wrapped in tea.Batch().
+func AnyInBoundsAndUpdate(model tea.Model, mouse tea.MouseMsg) (tea.Model, tea.Cmd) {
+	DefaultManager.checkInitialized()
+	return DefaultManager.AnyInBoundsAndUpdate(model, mouse)
+}

--- a/messages.go
+++ b/messages.go
@@ -21,7 +21,6 @@ type MsgZoneInBounds struct {
 func (m *Manager) findInBounds(mouse tea.MouseMsg) []*ZoneInfo {
 	var keys []string
 	var zones []*ZoneInfo
-	var zone *ZoneInfo
 
 	m.zoneMu.RLock()
 	for k := range m.zones {
@@ -30,7 +29,7 @@ func (m *Manager) findInBounds(mouse tea.MouseMsg) []*ZoneInfo {
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		zone = m.zones[k]
+		zone := m.zones[k]
 		if zone.InBounds(mouse) {
 			zones = append(zones, zone)
 		}

--- a/messages.go
+++ b/messages.go
@@ -18,13 +18,7 @@ type MsgZoneInBounds struct {
 	Event tea.MouseMsg // The mouse event that caused the zone to be in bounds.
 }
 
-// AnyInBounds sends a MsgZoneInBounds message to the provided model for each zone
-// that is in the bounds of the provided mouse event. The results of the call to
-// Update() are discarded.
-//
-// Note that if multiple zones are within bounds, each one will be sent as an event
-// in alphabetical sorted order of the ID.
-func (m *Manager) AnyInBounds(model tea.Model, mouse tea.MouseMsg) {
+func (m *Manager) findInBounds(mouse tea.MouseMsg) []*ZoneInfo {
 	var keys []string
 	var zones []*ZoneInfo
 	var zone *ZoneInfo
@@ -42,6 +36,18 @@ func (m *Manager) AnyInBounds(model tea.Model, mouse tea.MouseMsg) {
 		}
 	}
 	m.zoneMu.RUnlock()
+
+	return zones
+}
+
+// AnyInBounds sends a MsgZoneInBounds message to the provided model for each zone
+// that is in the bounds of the provided mouse event. The results of the call to
+// Update() are discarded.
+//
+// Note that if multiple zones are within bounds, each one will be sent as an event
+// in alphabetical sorted order of the ID.
+func (m *Manager) AnyInBounds(model tea.Model, mouse tea.MouseMsg) {
+	zones := m.findInBounds(mouse)
 
 	for _, zone := range zones {
 		_, _ = model.Update(MsgZoneInBounds{Zone: zone, Event: mouse})

--- a/messages.go
+++ b/messages.go
@@ -19,12 +19,12 @@ type MsgZoneInBounds struct {
 }
 
 func (m *Manager) findInBounds(mouse tea.MouseMsg) []*ZoneInfo {
-	var keys []string
 	var zones []*ZoneInfo
 
 	m.zoneMu.RLock()
 	defer m.zoneMu.RUnlock()
 
+	keys := make([]string, 0, len(m.zones))
 	for k := range m.zones {
 		keys = append(keys, k)
 	}

--- a/messages.go
+++ b/messages.go
@@ -23,6 +23,8 @@ func (m *Manager) findInBounds(mouse tea.MouseMsg) []*ZoneInfo {
 	var zones []*ZoneInfo
 
 	m.zoneMu.RLock()
+	defer m.zoneMu.RUnlock()
+
 	for k := range m.zones {
 		keys = append(keys, k)
 	}
@@ -34,7 +36,6 @@ func (m *Manager) findInBounds(mouse tea.MouseMsg) []*ZoneInfo {
 			zones = append(zones, zone)
 		}
 	}
-	m.zoneMu.RUnlock()
 
 	return zones
 }

--- a/messages.go
+++ b/messages.go
@@ -40,6 +40,21 @@ func (m *Manager) findInBounds(mouse tea.MouseMsg) []*ZoneInfo {
 	return zones
 }
 
+// AnyInBoundsAndUpdate is the same as AnyInBounds; except the results of the calls
+// to Update() are carried through and returned.
+//
+// The tea.Cmd's that comd off the calls to Update() are wrapped in tea.Batch().
+func (m *Manager) AnyInBoundsAndUpdate(model tea.Model, mouse tea.MouseMsg) (tea.Model, tea.Cmd) {
+	zones := m.findInBounds(mouse)
+
+	cmds := make([]tea.Cmd, len(zones))
+	for i, zone := range zones {
+		model, cmds[i] = model.Update(MsgZoneInBounds{Zone: zone, Event: mouse})
+	}
+
+	return model, tea.Batch(cmds...)
+}
+
 // AnyInBounds sends a MsgZoneInBounds message to the provided model for each zone
 // that is in the bounds of the provided mouse event. The results of the call to
 // Update() are discarded.

--- a/messages_test.go
+++ b/messages_test.go
@@ -65,3 +65,53 @@ func TestAnyInBounds(t *testing.T) {
 		t.Error("expected true")
 	}
 }
+
+type testModelValue struct {
+	received []tea.Msg
+}
+
+func (m testModelValue) Init() tea.Cmd {
+	return nil
+}
+
+func (m testModelValue) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.MouseMsg:
+		return AnyInBoundsAndUpdate(m, msg)
+	case MsgZoneInBounds:
+		m.received = append(m.received, msg)
+	}
+	return m, nil
+}
+
+func (m testModelValue) View() string {
+	// Starts at X:4, Y:2, ends at X:12, Y:3.
+	return "test\nfoo\naaa " + Mark("foo", "bar\ntest123456789") + " aaa\nbaz"
+}
+
+func TestAnyInBoundsAndUpdate(t *testing.T) {
+	var m tea.Model = testModelValue{}
+	_ = Scan(m.View())
+	time.Sleep(100 * time.Millisecond)
+	xy := Get("foo")
+	if xy.IsZero() {
+		t.Error("id not found")
+	}
+
+	m, _ = m.Update(tea.MouseMsg{X: 4, Y: 2})
+	time.Sleep(100 * time.Millisecond)
+
+	var contains bool
+	for _, msg := range m.(testModelValue).received {
+		if evt, ok := msg.(MsgZoneInBounds); ok {
+			if evt.Zone.id == xy.id {
+				contains = true
+				break
+			}
+		}
+	}
+
+	if !contains {
+		t.Error("expected true")
+	}
+}


### PR DESCRIPTION
## 🚀 Changes proposed by this PR

`AnyInBounds` discards the results of `Update()`. This makes it useless for value-based models, and doesn't let us use it to trigger `tea.Cmd`s.

This PR adds `AnyInBoundsAndUpdate` (I'm not tied to the name); which *doesn't* discard the results of `Update()`, instead carrying updates to the model through the events, and returning the final `tea.Model` and resulting `tea.Cmd`s.

I also refactored a bit to share the logic between these two functions, and changed said factored-out code to reduce allocations a bit.

### 🧰 Type of change

- [x] New feature (non-breaking change which adds functionality).

### 🤝 Requirements

- [x] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [x] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [x] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] 🔎 I have performed a self-review of my own changes.
- [x] 🎨 My changes follow the style guidelines of this project.
<!-- Include the below if this is a code change, if just documentation, ❌ remove this section. -->
- [x] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [x] 📝 I have made corresponding changes to the documentation.
- [x] 🧪 I have included tests (if necessary) for this change.
