### PR TITLE
use private CSI sequence for marking

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -17,7 +17,14 @@ const (
 	// part of the width of the view.
 	identStart   = '\x1B' // ANSI escape code.
 	identBracket = '['
-	identEnd     = 'z' // escape terminator.
+	// The escape terminator.
+	//
+	// Refs:
+	//  - https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
+	//    > A subset of arrangements was declared "private" so that terminal manufacturers could insert
+	//    > their own sequences without conflicting with the standard. Sequences containing the parameter
+	//    > bytes <=>? or the final bytes 0x70-0x7E (p-z{|}~) are private.
+	identEnd = 'z' // escape terminator.
 )
 
 var (

--- a/manager.go
+++ b/manager.go
@@ -17,7 +17,7 @@ const (
 	// part of the width of the view.
 	identStart   = '\x1B' // ANSI escape code.
 	identBracket = '['
-	identEnd     = 'Z' // escape terminator.
+	identEnd     = 'z' // escape terminator.
 )
 
 var (


### PR DESCRIPTION
<!--
  🙏 Thanks for submitting a pull request to bubblezone! Please make sure to read our
  Contributing Guidelines, and Code of Conduct.

  ❌ You can remove any sections of this template that are not applicable to your PR.
-->

## 🚀 Changes proposed by this PR

<!-- REQUIRED:
  Please include a summary of the change and which issue is fixed, or what feature is
  implemented. Include relevant motivation and context.
-->


### 🔗 Related bug reports/feature requests

<!--
  Does this PR relate to any bug reports and/or feature requests? Some examples:
  ❌ Remove section if there are no existing requests and/or issues.
-->
ISSUE: The ANSI CSI sequence used for marking should be a private one #19

### 🧰 Type of change

<!-- REQUIRED: Please mark which one applies to this change, ❌ remove the others. -->
- [✔ ] Bug fix (non-breaking change which fixes an issue).

Use private CSI sequence instead of the already defined CBT CSI sequence.

Fixes #19

### 📝 Notes to reviewer

<!--
  If needed, leave any special pointers for reviewing or testing your PR. If necessary,
  include things like screenshots (where beneficial), to help demonstrate the changes.
-->

https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences

"A subset of arrangements was declared "private" so that terminal manufacturers could insert their own sequences without conflicting with the standard. Sequences containing the parameter bytes <=>? or the final bytes 0x70–0x7E (p–z{|}~) are private. "

---

https://www.ecma-international.org/wp-content/uploads/ECMA-48_5th_edition_june_1991.pdf

5.4.d) F is the Final Byte; it consists of a bit combination from 04/00 to 07/14; it terminates the control sequence and together with the Intermediate Bytes, if present, identifies the control function.

**Bit combinations 07/00 to 07/14 are available as Final Bytes of control sequences for private (or experimental) use.**

5.4 Table 3: ("Z" = column 05, row 10 -> "CBT")

---

https://vt100.net/docs/vt510-rm/chapter4.html (search for "CBT)

### 🤝 Requirements

- [✔ ] ✍ I have read and agree to this projects [Code of Conduct](../../blob/master/.github/CODE_OF_CONDUCT.md).
- [✔ ] ✍ I have read and agree to this projects [Contribution Guidelines](../../blob/master/.github/CONTRIBUTING.md).
- [✔ ] ✍ I have read and agree to the [Developer Certificate of Origin](https://developercertificate.org/).
- [ ✔] 🔎 I have performed a self-review of my own changes.
- [ ✔] 🎨 My changes follow the style guidelines of this project.
<!-- Include the below if this is a code change, if just documentation, ❌ remove this section. -->
- [ ] 💬 My changes as properly commented, primarily for hard-to-understand areas.
- [ ] 📝 I have made corresponding changes to the documentation.
- [ ] 🧪 I have included tests (if necessary) for this change.
